### PR TITLE
Dev fix: Script to download and sign marp, and setup your team

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,17 @@ Sidekick is a local-first native LLM application for macOS. Download it and ask 
 - Open source. What's the point of running local AI if you can't audit that it's actually running locally?
 - Context aware. Understands and accesses your files, folders, and even content on the web.
 
+## Developer Setup
+
+**Requirements**
+- A Mac with Apple Silicon
+- RAM ≥ 8 GB
+
+1. Clone this repository.
+2. Run `./setup.sh` to change the team in the Xcode project and download and sign the `marp` binary.
+   - The `marp` binary is required for building and must be signed to create presentations.
+3. Open and run in Xcode.
+
 ## Contributing
 
 Contributions are very welcome. Let's make Sidekick simple and powerful.

--- a/scripts/entitlements-marp.plist
+++ b/scripts/entitlements-marp.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-jit</key>
+        <true/>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+        <key>com.apple.security.cs.disable-executable-page-protection</key>
+        <true/>
+    </dict>
+</plist>

--- a/scripts/setup-marp.sh
+++ b/scripts/setup-marp.sh
@@ -6,6 +6,12 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+read -p "The Marp CLI binary will be downloaded and installed from https://github.com/marp-team/marp-cli/releases/download/v4.1.2/marp-cli-v4.1.2-mac.tar.gz. Do you want to proceed? (yes/no): " CONFIRM
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "Installation cancelled."
+    exit 0
+fi
+
 TEAM=$1
 
 # Download the Marp CLI version 4.1.2 for macOS from the official GitHub releases

--- a/scripts/setup-marp.sh
+++ b/scripts/setup-marp.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Check if a team identifier is provided as an argument
+# Check if a code signing identity is provided as an argument
 if [ -z "$1" ]; then
-    echo "Usage: $0 <team>"
-    echo "example: $0 KM2C4ZAVPJ"
+    echo "Usage: $0 <code signing identity>"
+    echo "example: $0 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     exit 1
 fi
 
@@ -12,7 +12,7 @@ if [[ "$CONFIRM" != "yes" ]]; then
     exit 0
 fi
 
-TEAM=$1
+CODE_SIGNING_IDENTITY=$1
 
 # Download the Marp CLI version 4.1.2 for macOS from the official GitHub releases
 curl -L -o marp-cli-v4.1.2-mac.tar.gz https://github.com/marp-team/marp-cli/releases/download/v4.1.2/marp-cli-v4.1.2-mac.tar.gz || { echo "Error downloading marp"; exit 1; }
@@ -21,11 +21,13 @@ curl -L -o marp-cli-v4.1.2-mac.tar.gz https://github.com/marp-team/marp-cli/rele
 tar -xzf marp-cli-v4.1.2-mac.tar.gz || { echo "Error extracting marp"; exit 1; }
 
 # Sign marp so it can be executed from Sidekick
-#codesign --force --options runtime --entitlements entitlements.plist --sign "$TEAM" ./marp
+codesign --force --options runtime --entitlements entitlements-marp.plist --sign "$CODE_SIGNING_IDENTITY" ./marp
 
 # Move the extracted Marp CLI binary to the specified directory
 # This directory seems to be part of the Sidekick project resources
-if [ -f marp ]; then mv marp Sidekick/Logic/View\ Controllers/Tools/Slide\ Studio/Resources/bin/marp || { echo "Error moving marp"; exit 1; }; fi
+if [ -f marp ]; then mv marp ../Sidekick/Logic/View\ Controllers/Tools/Slide\ Studio/Resources/bin/marp || { echo "Error moving marp"; exit 1; }; fi
 
 # Remove the downloaded tar.gz file to clean up
 rm marp-cli-v4.1.2-mac.tar.gz || { echo "Error removing marp archive. You may need to manually remove the marp-cli-v4.1.2-mac.tar.gz file."; }
+
+echo "Successfully signed and copied marp to the appropriate location. You should be able to build and run Sidekick."

--- a/scripts/setup-marp.sh
+++ b/scripts/setup-marp.sh
@@ -9,21 +9,17 @@ fi
 TEAM=$1
 
 # Download the Marp CLI version 4.1.2 for macOS from the official GitHub releases
-curl -L -o marp-cli-v4.1.2-mac.tar.gz https://github.com/marp-team/marp-cli/releases/download/v4.1.2/marp-cli-v4.1.2-mac.tar.gz
+curl -L -o marp-cli-v4.1.2-mac.tar.gz https://github.com/marp-team/marp-cli/releases/download/v4.1.2/marp-cli-v4.1.2-mac.tar.gz || { echo "Error downloading marp"; exit 1; }
 
 # Extract the downloaded tar.gz file
-tar -xzf marp-cli-v4.1.2-mac.tar.gz
+tar -xzf marp-cli-v4.1.2-mac.tar.gz || { echo "Error extracting marp"; exit 1; }
 
 # Sign marp so it can be executed from Sidekick
 #codesign --force --options runtime --entitlements entitlements.plist --sign "$TEAM" ./marp
 
 # Move the extracted Marp CLI binary to the specified directory
 # This directory seems to be part of the Sidekick project resources
-mv marp Sidekick/Logic/View\ Controllers/Tools/Slide\ Studio/Resources/bin/marp
+if [ -f marp ]; then mv marp Sidekick/Logic/View\ Controllers/Tools/Slide\ Studio/Resources/bin/marp || { echo "Error moving marp"; exit 1; }; fi
 
 # Remove the downloaded tar.gz file to clean up
-rm marp-cli-v4.1.2-mac.tar.gz
-
-
-# TODO: take a team parameter
-
+rm marp-cli-v4.1.2-mac.tar.gz || { echo "Error removing marp archive. You may need to manually remove the marp-cli-v4.1.2-mac.tar.gz file."; }

--- a/scripts/setup-marp.sh
+++ b/scripts/setup-marp.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Check if a team identifier is provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <team>"
+    echo "example: $0 KM2C4ZAVPJ"
+    exit 1
+fi
+
+TEAM=$1
+
+# Download the Marp CLI version 4.1.2 for macOS from the official GitHub releases
+curl -L -o marp-cli-v4.1.2-mac.tar.gz https://github.com/marp-team/marp-cli/releases/download/v4.1.2/marp-cli-v4.1.2-mac.tar.gz
+
+# Extract the downloaded tar.gz file
+tar -xzf marp-cli-v4.1.2-mac.tar.gz
+
+# Sign marp so it can be executed from Sidekick
+#codesign --force --options runtime --entitlements entitlements.plist --sign "$TEAM" ./marp
+
+# Move the extracted Marp CLI binary to the specified directory
+# This directory seems to be part of the Sidekick project resources
+mv marp Sidekick/Logic/View\ Controllers/Tools/Slide\ Studio/Resources/bin/marp
+
+# Remove the downloaded tar.gz file to clean up
+rm marp-cli-v4.1.2-mac.tar.gz
+
+
+# TODO: take a team parameter
+

--- a/scripts/setup-team.sh
+++ b/scripts/setup-team.sh
@@ -8,9 +8,10 @@ if [ -z "$1" ]; then
 fi
 
 TEAM=$1
-PROJECT_FILE="Sidekick.xcodeproj/project.pbxproj"
+PROJECT_FILE="../Sidekick.xcodeproj/project.pbxproj"
 
 # Use sed to search and replace the DEVELOPMENT_TEAM value in the project file
 # The pattern matches lines with "DEVELOPMENT_TEAM = [A-Z0-9]*;" and replaces the value
 # with the provided team identifier. The change is made in-place using the -i flag.
 sed -i '' "s/DEVELOPMENT_TEAM = [A-Z0-9]*;/DEVELOPMENT_TEAM = $TEAM;/g" "$PROJECT_FILE" || { echo "Error setting team in Xcode project. You may need to manually change the team."; }
+echo "Successfully added your team to the Xcode project: $PROJECT_FILE"

--- a/scripts/setup-team.sh
+++ b/scripts/setup-team.sh
@@ -13,4 +13,4 @@ PROJECT_FILE="Sidekick.xcodeproj/project.pbxproj"
 # Use sed to search and replace the DEVELOPMENT_TEAM value in the project file
 # The pattern matches lines with "DEVELOPMENT_TEAM = [A-Z0-9]*;" and replaces the value
 # with the provided team identifier. The change is made in-place using the -i flag.
-sed -i '' "s/DEVELOPMENT_TEAM = [A-Z0-9]*;/DEVELOPMENT_TEAM = $TEAM;/g" "$PROJECT_FILE"
+sed -i '' "s/DEVELOPMENT_TEAM = [A-Z0-9]*;/DEVELOPMENT_TEAM = $TEAM;/g" "$PROJECT_FILE" || { echo "Error setting team in Xcode project. You may need to manually change the team."; }

--- a/scripts/setup-team.sh
+++ b/scripts/setup-team.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Check if a team identifier is provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <team>"
+    echo "example: $0 KM2C4ZAVPJ"
+    exit 1
+fi
+
+TEAM=$1
+PROJECT_FILE="Sidekick.xcodeproj/project.pbxproj"
+
+# Use sed to search and replace the DEVELOPMENT_TEAM value in the project file
+# The pattern matches lines with "DEVELOPMENT_TEAM = [A-Z0-9]*;" and replaces the value
+# with the provided team identifier. The change is made in-place using the -i flag.
+sed -i '' "s/DEVELOPMENT_TEAM = [A-Z0-9]*;/DEVELOPMENT_TEAM = $TEAM;/g" "$PROJECT_FILE"

--- a/setup.sh
+++ b/setup.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 # Check if a team identifier is provided as an argument
-if [ -z "$1" ]; then
-    echo "Usage: $0 <team>"
-    echo "example: $0 KM2C4ZAVPJ"
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <team> <code signing identitiy>"
+    echo "example: $0 KM2C4ZAVPJ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
     exit 1
 fi
 
 TEAM=$1
+CODE_SIGNING_IDENTITY=$2
 
+cd scripts
 # Run our other 2 setup scripts
 # Setup the team in the Xcode project
-./scripts/setup-team.sh "$TEAM"
+./setup-team.sh "$TEAM"
 # Download and sign marp to support presentation creation
-./scripts/setup-marp.sh "$TEAM"
-
-
+./setup-marp.sh "$CODE_SIGNING_IDENTITY"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Check if a team identifier is provided as an argument
+if [ -z "$1" ]; then
+    echo "Usage: $0 <team>"
+    echo "example: $0 KM2C4ZAVPJ"
+    exit 1
+fi
+
+TEAM=$1
+
+# Run our other 2 setup scripts
+# Setup the team in the Xcode project
+./scripts/setup-team.sh "$TEAM"
+# Download and sign marp to support presentation creation
+./scripts/setup-marp.sh "$TEAM"
+
+


### PR DESCRIPTION
## Summary of Changes
This pull request introduces a developer setup guide and scripts to automate the process of configuring the Sidekick project for local development. It includes instructions in the README, and scripts to download and sign the `marp` binary (used for creating presentations) and to set the development team in the Xcode project file. The scripts require a team identifier as an argument.

### Highlights
* **Developer Setup Guide**: Adds a section to the README.md with instructions on how to set up the project for local development, including hardware requirements and steps to run the setup scripts.
* **Setup Scripts**: Introduces three new shell scripts: `setup.sh` (main entry point), `scripts/setup-marp.sh` (downloads and configures the marp binary), and `scripts/setup-team.sh` (sets the development team in the Xcode project).
* **Marp Integration**: Automates the download and placement of the `marp` binary, which is required for building presentations within Sidekick.
* **Team Configuration**: Automates setting the Xcode development team ID in the project file, streamlining the setup process for new developers.
