### PR TITLE
UX: Sidebar buttons extend the full width, and a separator separates the buttons from list content

### DIFF
--- a/Sidekick/Views/Chat/Conversation/ConversationManagerView.swift
+++ b/Sidekick/Views/Chat/Conversation/ConversationManagerView.swift
@@ -168,6 +168,7 @@ struct ConversationManagerView: View {
 		) {
 			ConversationNavigationListView()
 			Spacer()
+            Divider()
 			sidebarButtons
 		}
 		.padding(.vertical, 7)

--- a/Sidekick/Views/Chat/Conversation/ConversationManagerView.swift
+++ b/Sidekick/Views/Chat/Conversation/ConversationManagerView.swift
@@ -168,7 +168,6 @@ struct ConversationManagerView: View {
 		) {
 			ConversationNavigationListView()
 			Spacer()
-            Divider()
 			sidebarButtons
 		}
 		.padding(.vertical, 7)

--- a/Sidekick/Views/Misc/Buttons/SidebarButtonView.swift
+++ b/Sidekick/Views/Misc/Buttons/SidebarButtonView.swift
@@ -31,6 +31,7 @@ struct SidebarButtonView: View {
 			.foregroundStyle(.secondary)
 			.font(.headline)
 			.fontWeight(.regular)
+            .frame(maxWidth: .infinity, alignment: .leading)
 			.padding(.horizontal, 8)
 			.padding(.vertical, 7)
 			.background(


### PR DESCRIPTION
Feel free to reject this if it doesn't fit with your vision. Do you have a discord to discuss any potential changes?

## Summary of Changes
Modifies the functionality of sidebar buttons to extend the full width of the sidebar and adding a visual separator. 

### Highlights
* **UI Enhancement**: The pull request focuses on improving the user interface by modifying the appearance of sidebar buttons.
* **Full-Width Buttons**: Sidebar button clickable space is now extended to occupy the full width of the sidebar, providing a more consistent and modern look. This makes it easier to interact with the buttons.
* **Visual Separator**: A divider has been added to visually separate the sidebar buttons from the list content, enhancing clarity and organization.

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/eca576e2-7710-49c1-91ce-5c13a0223165" />
