### PR TITLE
Add MiniMax as built-in popular provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Sidekick can even respond with the latest information using **web search**, spee
 
 In addition to its core local-first capabilities, Sidekick allows you to bring your own key for OpenAI compatible APIs. This allows you to tap into additional remote models while still preserving a primarily local-first workflow.
 
+Sidekick ships with built-in presets for popular providers, including **OpenAI**, **Anthropic**, **Google AI Studio**, **DeepSeek**, **Groq**, **MiniMax**, **Mistral**, **xAI**, and more — just select a provider and enter your API key to get started.
+
 ### Function Calling
 
 Sidekick can call functions to boost the mathematical and logical capabilities of models, and to execute actions. Functions are called sequentially in a loop until a result is obtained.

--- a/Sidekick/Types/Model/Provider.swift
+++ b/Sidekick/Types/Model/Provider.swift
@@ -51,6 +51,11 @@ public struct Provider: Identifiable {
             supportsToolCalling: true
         ),
         Provider(
+            name: "MiniMax",
+            endpointUrl: URL(string: "https://api.minimax.io/v1")!,
+            supportsToolCalling: true
+        ),
+        Provider(
             name: "Mistral",
             endpointUrl: URL(string: "https://api.mistral.ai/v1")!
         ),

--- a/SidekickTests/SidekickTests.swift
+++ b/SidekickTests/SidekickTests.swift
@@ -171,6 +171,125 @@ struct SidekickTests {
         #expect(paragraphStyles[2].paragraphSpacingBefore <= 0.5)
     }
 
+    // MARK: - Provider Tests
+
+    @Test func popularProvidersContainsMiniMax() async throws {
+        let minimax = Provider.popularProviders.first { $0.name == "MiniMax" }
+        #expect(minimax != nil)
+        #expect(minimax?.endpointUrl.absoluteString == "https://api.minimax.io/v1")
+        #expect(minimax?.supportsToolCalling == true)
+    }
+
+    @Test func popularProvidersAreSortedAlphabetically() async throws {
+        let names = Provider.popularProviders.map(\.name)
+        let sorted = names.sorted()
+        #expect(names == sorted)
+    }
+
+    @Test func providerIdUsesName() async throws {
+        let minimax = Provider.popularProviders.first { $0.name == "MiniMax" }
+        #expect(minimax?.id == "MiniMax")
+    }
+
+    @Test func allPopularProvidersHaveValidEndpoints() async throws {
+        for provider in Provider.popularProviders {
+            #expect(provider.endpointUrl.scheme == "http" || provider.endpointUrl.scheme == "https")
+            #expect(!provider.name.isEmpty)
+        }
+    }
+
+    // MARK: - KnownModel Organization Tests
+
+    @Test func minimaxOrganizationMapsCorrectly() async throws {
+        let org = KnownModel.Organization.from(string: "minimax")
+        #expect(org == .minimax)
+    }
+
+    @Test func minimaxOrganizationHasCorrectDisplayName() async throws {
+        #expect(KnownModel.Organization.minimax.rawValue == "Minimax")
+    }
+
+    @Test func minimaxModelFullIdentifierUsesCorrectPrefix() async throws {
+        let model = KnownModel(
+            primaryName: "MiniMax-M2.7",
+            organization: .minimax,
+            capabilities: [.reasoning]
+        )
+        #expect(model.fullIdentifier == "minimax/MiniMax-M2.7")
+        #expect(model.isReasoningModel == true)
+    }
+
+    @Test func minimaxMModelDetectedAsReasoningByOpenRouter() async throws {
+        // Simulate OpenRouter model detection: "minimax-m" triggers reasoning
+        let modelName = "minimax-m2.7"
+        #expect(modelName.contains("minimax-m"))
+    }
+
+    @Test func minimaxHighspeedModelFullIdentifier() async throws {
+        let model = KnownModel(
+            primaryName: "MiniMax-M2.7-highspeed",
+            organization: .minimax,
+            capabilities: [.reasoning]
+        )
+        #expect(model.fullIdentifier == "minimax/MiniMax-M2.7-highspeed")
+        #expect(model.isReasoningModel == true)
+    }
+
+    @Test func minimaxModelFindByNormalizedIdentifier() async throws {
+        let models = [
+            KnownModel(
+                primaryName: "MiniMax-M2.7",
+                organization: .minimax,
+                capabilities: [.reasoning]
+            ),
+            KnownModel(
+                primaryName: "MiniMax-M2.7-highspeed",
+                organization: .minimax,
+                capabilities: [.reasoning]
+            ),
+        ]
+        let found = KnownModel.findModel(
+            byIdentifier: "minimax/MiniMax-M2.7",
+            in: models
+        )
+        #expect(found != nil)
+        #expect(found?.primaryName == "MiniMax-M2.7")
+    }
+
+    // MARK: - Integration Tests (MiniMax Provider)
+
+    @Test func minimaxProviderToolCallingDetection() async throws {
+        // When endpoint matches MiniMax, providerSupportsToolCalling should
+        // find it in the popularProviders list
+        let minimaxUrl = "https://api.minimax.io/v1"
+        let match = Provider.popularProviders.first {
+            minimaxUrl == $0.endpointUrl.absoluteString
+        }
+        #expect(match != nil)
+        #expect(match?.supportsToolCalling == true)
+    }
+
+    @Test func minimaxOrganizationIncludedInCaseIterable() async throws {
+        let allOrgs = KnownModel.Organization.allCases
+        #expect(allOrgs.contains(.minimax))
+    }
+
+    @Test func minimaxKnownModelRoundTrip() async throws {
+        // Create a MiniMax model, encode to JSON, decode back
+        let original = KnownModel(
+            primaryName: "MiniMax-M2.7",
+            organization: .minimax,
+            modalities: [.text],
+            capabilities: [.reasoning]
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(KnownModel.self, from: data)
+        #expect(decoded.primaryName == "MiniMax-M2.7")
+        #expect(decoded.organization == .minimax)
+        #expect(decoded.isReasoningModel == true)
+        #expect(decoded.fullIdentifier == "minimax/MiniMax-M2.7")
+    }
+
     private func paragraphStyles(
         in attributedText: NSAttributedString
     ) -> [NSParagraphStyle] {


### PR DESCRIPTION
## Summary

- Add **MiniMax** (`https://api.minimax.io/v1`) to the popular providers dropdown in remote model settings, with tool calling enabled
- MiniMax offers OpenAI-compatible reasoning models (M2.7, M2.7-highspeed) with 1M context window
- The organization was already recognized in `KnownModel.swift` — this PR completes the integration by adding the provider endpoint preset
- Update README to list MiniMax among the built-in provider presets

## Changes

| File | Change |
|------|--------|
| `Provider.swift` | Add MiniMax entry to `popularProviders` array |
| `SidekickTests.swift` | 12 new tests: provider config, organization mapping, model resolution, JSON round-trip |
| `README.md` | List MiniMax among supported providers |

3 files changed, 126 additions

## Test Plan

- [ ] Verify MiniMax appears in the provider dropdown in Settings → Remote Model
- [ ] Select MiniMax provider and confirm endpoint auto-fills to `https://api.minimax.io/v1`
- [ ] Enter a MiniMax API key and connect to MiniMax-M2.7 model
- [ ] Confirm tool calling is enabled when MiniMax endpoint is selected
- [ ] Run unit tests: `xcodebuild test` to verify all 12 new tests pass