### PR TITLE
feat: add Requesty as an OpenAI-compatible provider

### DIFF
--- a/Sidekick/Types/Model/Provider.swift
+++ b/Sidekick/Types/Model/Provider.swift
@@ -64,6 +64,10 @@ public struct Provider: Identifiable {
             endpointUrl: URL(string: "https://openrouter.ai/api/v1")!
         ),
         Provider(
+            name: "Requesty",
+            endpointUrl: URL(string: "https://router.requesty.ai/v1")!
+        ),
+        Provider(
             name: "xAI",
             endpointUrl: URL(string: "https://api.x.ai/v1")!
         ),


### PR DESCRIPTION
This adds Requesty to the list of popular providers, mirroring the existing OpenRouter entry.

Requesty is an OpenAI-compatible LLM gateway, so it slots into `Provider.popularProviders` with its OpenAI-compatible endpoint (`https://router.requesty.ai/v1`), the same way OpenRouter and the other providers are listed. Model discovery in `KnownModel.swift` reads the standard OpenAI shaped `/models` response, which Requesty serves identically, so no other changes are needed.

Verification: I tested the endpoint live before opening this. `GET https://router.requesty.ai/v1/models` returned 200 (around 578 models), and a chat completion with `openai/gpt-4o-mini` against `https://router.requesty.ai/v1/chat/completions` returned 200.

Docs: https://requesty.ai , https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it is not a fit.
