### PR TITLE
fix: Restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,10 @@ This project would not be possible without the hard work of:
 
 ## Star History
 
-<a href="https://star-history.com/#johnbean393/Sidekick&Date">
+<a href="https://star-history.dera.page/#johnbean393/Sidekick&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=johnbean393/Sidekick&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=johnbean393/Sidekick&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=johnbean393/Sidekick&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=johnbean393/Sidekick&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=johnbean393/Sidekick&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=johnbean393/Sidekick&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README was broken because the original star-history.com service relied on GitHub's Stargazer API, which has since been shut down. As a result, no stars chart was displayed on the project page at all, which is a shame for a project of this size.

This PR switches the chart to the dera.page instance, which uses a different data source that requires no API token, restoring the star history chart.